### PR TITLE
feat(index.js): add invisibility check wrt z-index

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,6 +104,18 @@ function isInvisible(element, options) {
     return true;
   }
 
+  // return true if element is under another element
+  if (
+    // check all 4 corners and the middle in case of rounded corners
+    !element.contains(document.elementFromPoint(elementLeft, elementTop)) &&
+    !element.contains(document.elementFromPoint(elementRight, elementTop)) &&
+    !element.contains(document.elementFromPoint(elementRight, elementBottom)) &&
+    !element.contains(document.elementFromPoint(elementLeft, elementBottom)) &&
+    !element.contains(document.elementFromPoint(elementRight - (elementWidth / 2), elementBottom - (elementHeight / 2)))
+  ) {
+    return true;
+  }
+
   // recursively check upwards ...
   return isInvisible(parentNode, {
     elementHeight,

--- a/src/index.js
+++ b/src/index.js
@@ -107,11 +107,11 @@ function isInvisible(element, options) {
   // return true if element is under another element
   if (
     // check all 4 corners and the middle in case of rounded corners
-    !element.contains(document.elementFromPoint(elementLeft, elementTop)) &&
-    !element.contains(document.elementFromPoint(elementRight, elementTop)) &&
-    !element.contains(document.elementFromPoint(elementRight, elementBottom)) &&
-    !element.contains(document.elementFromPoint(elementLeft, elementBottom)) &&
-    !element.contains(document.elementFromPoint(elementLeft + (elementWidth / 2), elementTop + (elementHeight / 2))) &&
+    // !element.contains(document.elementFromPoint(elementLeft, elementTop)) &&
+    // !element.contains(document.elementFromPoint(elementRight, elementTop)) &&
+    // !element.contains(document.elementFromPoint(elementRight, elementBottom)) &&
+    // !element.contains(document.elementFromPoint(elementLeft, elementBottom)) &&
+    // !element.contains(document.elementFromPoint(elementLeft + (elementWidth / 2), elementTop + (elementHeight / 2)))
     // if element is outside viewport
     !element.contains(elementFromAbsolutePoint(elementLeft + (elementWidth / 2), elementTop + (elementHeight / 2)))
   ) {

--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,13 @@ function isInvisible(element, options) {
 
   // return true if element is under another element
   if (
-    // check the middle in case of rounded corners
+    // check all 4 corners and the middle in case of rounded corners
+    !element.contains(document.elementFromPoint(elementLeft, elementTop)) &&
+    !element.contains(document.elementFromPoint(elementRight, elementTop)) &&
+    !element.contains(document.elementFromPoint(elementRight, elementBottom)) &&
+    !element.contains(document.elementFromPoint(elementLeft, elementBottom)) &&
+    !element.contains(document.elementFromPoint(elementLeft + (elementWidth / 2), elementTop + (elementHeight / 2))) &&
+    // if element is outside viewport
     !element.contains(elementFromAbsolutePoint(elementLeft + (elementWidth / 2), elementTop + (elementHeight / 2)))
   ) {
     return true;

--- a/src/index.js
+++ b/src/index.js
@@ -106,12 +106,8 @@ function isInvisible(element, options) {
 
   // return true if element is under another element
   if (
-    // check all 4 corners and the middle in case of rounded corners
-    !element.contains(document.elementFromPoint(elementLeft, elementTop)) &&
-    !element.contains(document.elementFromPoint(elementRight, elementTop)) &&
-    !element.contains(document.elementFromPoint(elementRight, elementBottom)) &&
-    !element.contains(document.elementFromPoint(elementLeft, elementBottom)) &&
-    !element.contains(document.elementFromPoint(elementRight - (elementWidth / 2), elementBottom - (elementHeight / 2)))
+    // check the middle in case of rounded corners
+    !element.contains(elementFromAbsolutePoint(elementLeft + (elementWidth / 2), elementTop + (elementHeight / 2)))
   ) {
     return true;
   }
@@ -180,6 +176,23 @@ function elementInDocument(element) {
     element = element.parentNode;
   }
   return false;
+}
+
+function elementFromAbsolutePoint(x, y) {
+  // Stash current Window Scroll
+  const scrollX = window.pageXOffset;
+  const scrollY = window.pageYOffset;
+  // Scroll to element
+  window.scrollTo(x, y);
+  // Calculate new relative element coordinates
+  const newX = x - window.pageXOffset;
+  const newY = y - window.pageYOffset;
+  // Grab the element
+  const elm = document.elementFromPoint(newX, newY);
+  // revert to the previous scroll location
+  window.scrollTo(scrollX, scrollY);
+  // returned the grabbed element at the absolute coordinates
+  return elm;
 }
 
 module.exports = isInvisible;

--- a/test/setup/z-index/index.html
+++ b/test/setup/z-index/index.html
@@ -1,0 +1,4 @@
+<body>
+  <script src="index.js"></script>
+  <script src="../style.js"></script>
+</body>

--- a/test/setup/z-index/index.js
+++ b/test/setup/z-index/index.js
@@ -13,10 +13,13 @@ const zindexStyle = `
   }
 
   .z-d {
+    top: 0px;
+    left: 0px;
+    width: 300px;
+    height: 300px;
+    position: fixed;
     z-index: 5 !important;
     background: blue !important;
-    position: relative;
-    top: -102px;
   }
 
 `;
@@ -29,28 +32,16 @@ const zindexMarkup = `
   z-index: higher
   <div class="wrapper">
     <div class="inline-block z-h"></div>
-    <div class="inline-block z-d"></div>
   </div>
 
   z-index: lower
   <div class="wrapper">
     <div class="inline-block z-l"></div>
-    <div class="inline-block z-d"></div>
   </div>
 
-`;
+  <div class="z-d"></div>
 
-// const defaultMarkup = `
-//   default element
-//   <div class="wrapper">
-//     <div class="inline-block z-d"></div>
-//   </div>
-//
-//   default element
-//   <div class="wrapper">
-//     <div class="inline-block z-d"></div>
-//   </div>
-// `;
+`;
 
 const zindexWrapperNode = document.createElement('div');
 zindexWrapperNode.innerHTML = zindexMarkup;

--- a/test/setup/z-index/index.js
+++ b/test/setup/z-index/index.js
@@ -1,0 +1,57 @@
+const zindexStyle = `
+
+  .z-h {
+    z-index: 999 !important;
+    position: relative;
+    background: red !important;
+  }
+
+  .z-l {
+    z-index: 1 !important;
+    position: relative;
+    background: red !important;
+  }
+
+  .z-d {
+    z-index: 5 !important;
+    background: blue !important;
+    position: relative;
+    top: -102px;
+  }
+
+`;
+
+const zindexStyleNode = document.createElement('style');
+zindexStyleNode.innerHTML = zindexStyle;
+document.head.appendChild(zindexStyleNode);
+
+const zindexMarkup = `
+  z-index: higher
+  <div class="wrapper">
+    <div class="inline-block z-h"></div>
+    <div class="inline-block z-d"></div>
+  </div>
+
+  z-index: lower
+  <div class="wrapper">
+    <div class="inline-block z-l"></div>
+    <div class="inline-block z-d"></div>
+  </div>
+
+`;
+
+// const defaultMarkup = `
+//   default element
+//   <div class="wrapper">
+//     <div class="inline-block z-d"></div>
+//   </div>
+//
+//   default element
+//   <div class="wrapper">
+//     <div class="inline-block z-d"></div>
+//   </div>
+// `;
+
+const zindexWrapperNode = document.createElement('div');
+zindexWrapperNode.innerHTML = zindexMarkup;
+document.body.appendChild(zindexWrapperNode);

--- a/test/z-index/z-index.js
+++ b/test/z-index/z-index.js
@@ -1,11 +1,11 @@
 const isInvisible = require('../../src/.');
 
-describe('is-invisible - basic', () => {
-  it('should return `false` if the element has higher z-index', () => {
+describe('is-invisible - z-index', () => {
+  it('should return `false` if the element has a higher z-index', () => {
     assert.isFalse(isInvisible(document.querySelector('.z-h')));
   });
 
-  it('should return `true` if the element has lower z-index', () => {
+  it('should return `true` if the element has a lower z-index', () => {
     assert.isTrue(isInvisible(document.querySelector('.z-l')));
   });
 });

--- a/test/z-index/z-index.js
+++ b/test/z-index/z-index.js
@@ -1,0 +1,11 @@
+const isInvisible = require('../../src/.');
+
+describe('is-invisible - basic', () => {
+  it('should return `false` if the element has higher z-index', () => {
+    assert.isFalse(isInvisible(document.querySelector('.z-h')));
+  });
+
+  it('should return `true` if the element has lower z-index', () => {
+    assert.isTrue(isInvisible(document.querySelector('.z-l')));
+  });
+});


### PR DESCRIPTION
Previously it didn't check for invisibility due to element being behind another element. Add support for invisibility check due to a lower z-index.

Closes #14 
